### PR TITLE
Replaced InfiniteReach with CityLink

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 نیبرلینک یک سیستم‌عامل OpenWRT شخصی‌سازی‌شده است که به مدیر سیستم امکان می‌دهد اینترنت استارلینک را با کاربران دیگر، مثلاً همسایه‌ها، به اشتراک بگذارد. این سیستم در حال حاضر امکاناتی مانند مدیریت کاربران، تفکیک مسیر (Split Tunneling) و مخفی‌سازی آی‌پی با استفاده از وی‌پی‌ان را فراهم می‌کند. در آینده، قابلیت‌های دیگری مانند لیست سفید (Whitelisting)، لیست سیاه (Blacklisting) و مدیریت ترافیک به نیبرلینک افزوده خواهد شد.
 
-اینفینیت ریچ (Infinite Reach) یکی از گزینه‌های نیبرلینک است که با استفاده از آن می‌توان از راه دور و با استفاده از اینترنت داخلی یک کشور، به‌صورت امن و ناشناس به استارلینک متصل شد. در حال حاضر، می‌توان با پروکسی‌هایی مانند SwitchyOmega، FoxyProxy و Potasto و همچنین با استفاده از Outline، از اینفینیت ریچ استفاده کرد.
+سیتی لینک (CityLink) یکی از گزینه‌های نیبرلینک است که با استفاده از آن می‌توان از راه دور و با استفاده از اینترنت داخلی یک کشور، به‌صورت امن و ناشناس به استارلینک متصل شد. در حال حاضر، می‌توان با پروکسی‌هایی مانند SwitchyOmega، FoxyProxy و Potasto و همچنین با استفاده از Outline، از سیتی لینک استفاده کرد.
 
 NeighborLink enables individuals in close proximity to a Starlink terminal to retain secure internet access, demonstrating its effectiveness in circumventing widespread internet restrictions.
 The core advantage of NeighborLink is providing resilient local internet access, designed to be impervious to nationwide shutdowns.
@@ -15,10 +15,10 @@ In scenarios where the government enforces a complete internet blackout, this sy
 
 Key developments including a user management dashboard, split tunneling and VPN technology have been implemented, with future enhancements planned for whitelisting, blacklisting, and traffic management.
 
-Infinite Reach is a feature to enable remote use of Starlink via the domestic internet. In essence, Infinite Reach is composed of two separate methods:
+CityLink is a feature to enable remote use of Starlink via the domestic internet. In essence, CityLink is composed of two separate methods:
 Proxy (such as SwitchyOmega, FoxyProxy, Potatso)
 Outline.
 Both the administrator and users can utilize either or both methods according to their needs.
-The Infinite Reach solution was designed with an understanding of, and in response to, the dual structure of Iran's internet - differences in domestic and international internet censorship.
+The CityLink solution was designed with an understanding of, and in response to, the dual structure of Iran's internet - differences in domestic and international internet censorship.
 
 The solution includes integrating a cloud server, empowering users to create personal servers, and implementing firewalls to conceal satellite connections. An assessment of Iranian internet providers favored fiber internet and point-to-point connections for their performance and security.

--- a/server/Iran_server/Iran_server_setup.sh
+++ b/server/Iran_server/Iran_server_setup.sh
@@ -224,7 +224,7 @@ deploy_service() {
         generate_string
         echo ""
         echo ""
-        echo "Copy the following string into the Infinitereach dashboard:"
+        echo "Copy the following string into the CityLink dashboard:"
         echo ""
         echo -e "\033[0;32m$(generate_string)\033[0m"
 
@@ -246,7 +246,7 @@ retrieve_service_config() {
 
     echo ""
     echo ""
-    echo "Copy the following string into the Infinitereach dashboard:"
+    echo "Copy the following string into the CityLink dashboard:"
     echo ""
     echo -e "\033[0;32m$KEYSTRING\033[0m"
 

--- a/src/files/etc/rc.local
+++ b/src/files/etc/rc.local
@@ -1,5 +1,7 @@
 # Run setup script
 # This script execute once at the device startup.
+# InfiniteReach = CityLink
+
 
 # last 2 letter of  mac address. added to the SSID
 IDENTIFIER=$(cat /sys/class/net/eth0/address | awk -F ':' '{print $6}');

--- a/src/files/www/dashboard.html
+++ b/src/files/www/dashboard.html
@@ -67,8 +67,8 @@
                     <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-hdd-network-fill" viewBox="0 0 16 16">
                         <path d="M2 2a2 2 0 0 0-2 2v1a2 2 0 0 0 2 2h5.5v3A1.5 1.5 0 0 0 6 11.5H.5a.5.5 0 0 0 0 1H6A1.5 1.5 0 0 0 7.5 14h1a1.5 1.5 0 0 0 1.5-1.5h5.5a.5.5 0 0 0 0-1H10A1.5 1.5 0 0 0 8.5 10V7H14a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2zm.5 3a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m2 0a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1"></path>
                     </svg>
-                    <span class="d-inline d-sm-none small">Inf Reach</span>
-                    <span class="d-none d-sm-inline">Infinite Reach</span>
+                    <span class="d-inline d-sm-none small">CityLink</span>
+                    <span class="d-none d-sm-inline">CityLink</span>
                 </button>
             </div>
             <div class="row mt-3">

--- a/src/files/www/ethernet.html
+++ b/src/files/www/ethernet.html
@@ -51,11 +51,11 @@
             <div class="alert alert-info alert-dismissible fade show" role="alert">
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                 <div>
-                    In this step, we connect NeighborLink to the Iranian internet. The goal is to ensure that you can access both domestic services and later, in the Infinite Reach section, connect remotely to Starlink via the domestic internet.
+                    In this step, we connect NeighborLink to the Iranian internet. The goal is to ensure that you can access both domestic services and later, in the CityLink section, connect remotely to Starlink via the domestic internet.
                 </div>
                 <br>
                 <div dir="rtl">
-                    در این مرحله نیبرلینک را به اینترنت ایران متصل می‌کنیم. هدف ما این است که هم بتوانیم از سرویس‌های داخلی ایران استفاده کنیم، هم بعدا در بخش Infinite Reach بتوانیم با استفاده از اینترنت ایران از راه دور به استارلینک وصل شویم.
+                    در این مرحله نیبرلینک را به اینترنت ایران متصل می‌کنیم. هدف ما این است که هم بتوانیم از سرویس‌های داخلی ایران استفاده کنیم، هم بعدا در بخش CityLink بتوانیم با استفاده از اینترنت ایران از راه دور به استارلینک وصل شویم.
                 </div>
             </div>
 

--- a/src/files/www/infinite_reach.html
+++ b/src/files/www/infinite_reach.html
@@ -26,7 +26,7 @@
                 </a>
             </div>
             <div class="col text-center">
-                <h6 class="mb-0">Step 5:<br>Infinite Reach - Setup Access to Starlink via Iran Internet</h6>
+                <h6 class="mb-0">Step 5:<br>CityLink - Setup Access to Starlink via Iran Internet</h6>
             </div>
             <div class="col-auto">
                 <a href="dashboard.html" class="btn btn-light">Dashboard  
@@ -43,7 +43,7 @@
             <!-- Note -->
             <div class="alert alert-info alert-dismissible fade show" role="alert" >
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
-                <strong>Configuring Remote Access (Infinite Reach):</strong> You can now set up your system to access your autonomous internet source (e.g., Starlink) remotely through the Iranian internet. We refer to this feature as "Infinite Reach." Please carefully follow the steps provided for a successful setup. If you do not require remote access to your Starlink connection, feel free to skip this step
+                <strong>Configuring Remote Access (CityLink):</strong> You can now set up your system to access your autonomous internet source (e.g., Starlink) remotely through the Iranian internet. We refer to this feature as "CityLink." Please carefully follow the steps provided for a successful setup. If you do not require remote access to your Starlink connection, feel free to skip this step
             </div>
             
             <!-- How to  -->
@@ -63,7 +63,7 @@
         <!-- Alert -->
         
 
-        <h2 class="text-warning mt-3">Infinite Reach Connection</h2>
+        <h2 class="text-warning mt-3">CityLink Connection</h2>
         <hr>
         <div class="container row">
             <div id="alertContainer" class="col"></div>
@@ -104,7 +104,7 @@
                 <div class="card">
                     
                     <div class="card-body">
-                        <h3 class="card-title">Outline Gate</h4>
+                        <h3 class="card-title">Outline Relay</h4>
                         <p class="card-text text-body fw-lighter" >Convert Global Outline config to use in Iran</p> 
                         <a href="outline.html" class="btn btn-outline-primary">setup</a>
                     </div>

--- a/src/files/www/outline.html
+++ b/src/files/www/outline.html
@@ -26,7 +26,7 @@
                 </a>
             </div>
             <div class="col text-center">
-                <h6 class="mb-0">Setup Outline Gate</h6>
+                <h6 class="mb-0">Setup Outline Relay</h6>
             </div>
 
         </div>
@@ -37,7 +37,7 @@
             <!-- Note -->
             <div class="alert alert-info alert-dismissible fade show" role="alert" >
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close" ></button>
-                <strong>Outline Gate:</strong> This section assists you in converting Outline keys. By converting the Outline key, the client will connect through the Iran internet and your Starlink to the Outline server. You can use either a free Outline key or your own Outline key for this process.
+                <strong>Outline Relay:</strong> This section assists you in converting Outline keys. By converting the Outline key, the client will connect through the Iran internet and your Starlink to the Outline server. You can use either a free Outline key or your own Outline key for this process.
             </div>
             
             <!-- How to  -->


### PR DESCRIPTION
Rename "InfiniteReach" to "Citylink" and update all references in user interfaces and messages to reflect the new name.