### PR TITLE
Remove Proxy SwitchyOmega from Recommendation Service due to Security Concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 نیبرلینک یک سیستم‌عامل OpenWRT شخصی‌سازی‌شده است که به مدیر سیستم امکان می‌دهد اینترنت استارلینک را با کاربران دیگر، مثلاً همسایه‌ها، به اشتراک بگذارد. این سیستم در حال حاضر امکاناتی مانند مدیریت کاربران، تفکیک مسیر (Split Tunneling) و مخفی‌سازی آی‌پی با استفاده از وی‌پی‌ان را فراهم می‌کند. در آینده، قابلیت‌های دیگری مانند لیست سفید (Whitelisting)، لیست سیاه (Blacklisting) و مدیریت ترافیک به نیبرلینک افزوده خواهد شد.
 
-سیتی لینک (CityLink) یکی از گزینه‌های نیبرلینک است که با استفاده از آن می‌توان از راه دور و با استفاده از اینترنت داخلی یک کشور، به‌صورت امن و ناشناس به استارلینک متصل شد. در حال حاضر، می‌توان با پروکسی‌هایی مانند SwitchyOmega، FoxyProxy و Potasto و همچنین با استفاده از Outline، از سیتی لینک استفاده کرد.
+سیتی لینک (CityLink) یکی از گزینه‌های نیبرلینک است که با استفاده از آن می‌توان از راه دور و با استفاده از اینترنت داخلی یک کشور، به‌صورت امن و ناشناس به استارلینک متصل شد. در حال حاضر، می‌توان با پروکسی‌هایی مانند  FoxyProxy و Potasto و همچنین با استفاده از Outline، از سیتی لینک استفاده کرد.
 
 NeighborLink enables individuals in close proximity to a Starlink terminal to retain secure internet access, demonstrating its effectiveness in circumventing widespread internet restrictions.
 The core advantage of NeighborLink is providing resilient local internet access, designed to be impervious to nationwide shutdowns.
@@ -16,7 +16,7 @@ In scenarios where the government enforces a complete internet blackout, this sy
 Key developments including a user management dashboard, split tunneling and VPN technology have been implemented, with future enhancements planned for whitelisting, blacklisting, and traffic management.
 
 CityLink is a feature to enable remote use of Starlink via the domestic internet. In essence, CityLink is composed of two separate methods:
-Proxy (such as SwitchyOmega, FoxyProxy, Potatso)
+Proxy (such as FoxyProxy and Potatso)
 Outline.
 Both the administrator and users can utilize either or both methods according to their needs.
 The CityLink solution was designed with an understanding of, and in response to, the dual structure of Iran's internet - differences in domestic and international internet censorship.

--- a/src/files/www/dashboard/proxy.html
+++ b/src/files/www/dashboard/proxy.html
@@ -66,13 +66,10 @@
                     </div>
                     <h6 class="alert-heading mb-1 text-center">Instruction:</h6>
                     <ul>
-                        <li>Choose and set up a <strong>proxy</strong>. For example, you can use the <strong>SwitchyOmega</strong> extension in your Chrome browser.</li>
+                        <li>Choose and set up a <strong>proxy</strong>.</li>
                         <li>In the proxy settings, ensure the protocol is set to HTTPS (TLS).</li>
                         <li>Enter the required information from the Proxy Info section into your proxy settings.</li>
                     </ul>
-                    <p>
-                        Tip: If you are using <strong>SwitchyOmega</strong> in Iran, you can enable <strong>client-side split tunneling</strong> for better performance. For more information, visit: this link: [https://bootmortis.github.io/iran-hosted-domains/#/switchyomega]
-                    </p>
                 </div>
                 <div dir="rtl" class="farsi-text">
                     <div class="position-absolute top-0 start-0" style="margin-top: 3px; margin-left: 3px;">
@@ -80,14 +77,10 @@
                     </div>
                     <h6 class="alert-heading mb-1 text-center">راهنما</h6>
                     <ul>
-                        <li>یک پروکسی انتخاب کرده و آن را نصب کنید. به‌عنوان مثال می‌توانید از افزونه SwitchyOmega در مرورگر کروم استفاده کنید.</li>
+                        <li>یک پروکسی انتخاب کرده و آن را نصب کنید.</li>
                         <li>در تنظیمات پروکسی دقت کنید که پروتکل HTTPS (TLS) را انتخاب کنید.</li>
                         <li>اطلاعات مورد نیاز را از بخش Proxy Info وارد کنید.</li>
                     </ul>
-                    <p>
-                        پیشنهاد: اگر در ایران از SwitchyOmega استفاده می‌کنید، می‌توانید در سمت کلاینت اسپلیت‌تانلینگ یا تفکیک مسیر کنید. برای اطلاعات بیشتر به لینک زیر مراجعه کنید:
-                        <a href="https://bootmortis.github.io/iran-hosted-domains/#/switchyomega">https://bootmortis.github.io/iran-hosted-domains/#/switchyomega</a>
-                    </p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
This PR removes Proxy SwitchyOmega from the recommended extensions in the instruction materials of our service. The extension has not been updated to comply with Manifest V3 standards, which introduces security and performance improvements.
Additionally, this opens a risk where users might install malicious alternatives with similar names, leading to potential malware infections.